### PR TITLE
docs: document the original 2016 architecture and page structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# wedwip documentation
+
+Documentation for the 10th-anniversary overhaul of the 2016 wedding website.
+
+## Architecture
+
+- [Original application architecture (2016)](architecture/original-application.md) —
+  the Rails 4.2 application: stack, routing, data model, components, integrations.
+- [Original page structure & frontend (2016)](architecture/original-page-structure.md) —
+  the Vitality Bootstrap theme, home page sections, stylesheets, scripts and images.
+
+## Security
+
+- Security posture assessment and remediation plan: see `security/` (added in the
+  security assessment PR).
+
+## Specs
+
+- [10th anniversary static site design](superpowers/specs/2026-06-11-anniversary-static-site-design.md) —
+  goals, chosen approach and the PR series plan for the redesign.

--- a/docs/architecture/original-application.md
+++ b/docs/architecture/original-application.md
@@ -1,0 +1,122 @@
+# Original Application Architecture (2016)
+
+`wedwip` ("Wedding Work In Progress") was the wedding website of Mauro & Beatrice,
+married on **1 October 2016**. It was a single-page-style dynamic website where invited
+guests registered, confirmed attendance (RSVP), suggested honeymoon stops and music, and
+left messages for the couple. This document describes the application as it was built in
+2016, for historical reference now that the dynamic application is retired.
+
+## Stack
+
+| Layer | Technology | Version |
+|-------|-----------|---------|
+| Language | Ruby | 2.2.1 |
+| Framework | Ruby on Rails | 4.2.6 |
+| App server | Puma | (Gemfile, unpinned) |
+| Database | PostgreSQL | 9.4 |
+| Templates | Haml (`haml-rails`) | — |
+| Auth | Devise | (unpinned) |
+| Forms | simple_form | — |
+| Decorators | Draper | — |
+| JS i18n | i18n-js | github master |
+| Asset pipeline | Sprockets + sass-rails + uglifier + coffee-rails | — |
+| Frontend | jQuery 1.11.0, Bootstrap 3.3.5, "Vitality" theme | vendored |
+| Hosting | Heroku (`Procfile`, `rails_12factor`) | — |
+| CI | Travis CI | Ruby 2.2.1 + PostgreSQL 9.4 |
+| Code quality | Codacy, Code Climate, RuboCop, ESLint, csslint | — |
+| Tests | RSpec (`rspec-rails` ~> 3.0), Capybara | — |
+
+A `dropbox-sdk` gem is declared in the Gemfile (intended for photo uploads) but is not
+used anywhere in the application code.
+
+## Request flow
+
+```
+Browser ──> Heroku (Puma) ──> Rails 4.2 ──> PostgreSQL 9.4
+                                │
+                                ├─ Devise (authentication, registration, password reset)
+                                ├─ StaticPagesController#home  (the whole site, auth-gated)
+                                ├─ Guests / Messages / Places  (JSON endpoints + datatables)
+                                └─ Sprockets asset pipeline (vendored theme assets)
+```
+
+The site is effectively a **single page** (`static_pages#home`) rendered server-side from
+Haml partials, with jQuery making JSON calls back to the Rails controllers for the
+dynamic features. **The entire home page required login** (`before_action
+:authenticate_user!`); anonymous visitors only saw the Devise login/registration screens.
+
+## Routing
+
+All public routes are wrapped in an optional `(:locale)` scope (`/en|it/`, default `it`):
+
+- `root` → `static_pages#home`
+- Devise (`users`): custom paths — `login`, `logout`, `secret` (password), `register`,
+  with overridden `passwords`, `registrations` and `sessions` controllers
+- `guests`, `messages`, `places`:
+  - localized `index` views (datatable listings for the couple)
+  - unlocalized `create` (+ `destroy` for guests) JSON endpoints used by the home page
+  - `GET …/datatable_list` JSON collection endpoints
+- `users#check` (async email existence check used by the password-reset flow) and
+  `users#update_password`
+
+## Data model
+
+```
+users ──< guests        (RSVP: name, surname; unique [name, surname]; capitalized on save)
+      ──< messages      (text, phone_number)
+      ──< places        (marker jsonb, address, reason — honeymoon suggestions from Google Maps)
+```
+
+`users` is the standard Devise table (database_authenticatable, registerable,
+recoverable, rememberable, trackable, validatable). Each invited household registered
+its own account; guests/messages/places rows belong to the registering user.
+
+Schema version: `20160613063039` (7 migrations, April–June 2016).
+
+## Server-side components
+
+- **Controllers** (`app/controllers/`)
+  - `ApplicationController`: CSRF protection (`:exception`), `set_locale` from params.
+  - `StaticPagesController#home`: loads the current user's guests and all place markers.
+  - `GuestsController`: JSON create/destroy of the current user's RSVP'd guests
+    (client sends a JSON string in `guest_json`).
+  - `MessagesController`, `PlacesController`: JSON `create` endpoints.
+  - `Users::*`: Devise overrides (sessions, registrations, passwords) plus
+    `UsersController#check` / `#update_password`.
+  - `DatatableList` concern: generic `datatable_list` action resolving model and Draper
+    decorator by controller name and rendering `shared/search.json.jbuilder`.
+- **Decorators** (`app/decorators/`): `GuestDecorator`, `MessageDecorator`,
+  `PlaceDecorator` format rows for the jQuery DataTables admin listings.
+- **Helpers**: `HtmlHelper`, `ApplicationHelper` (includes `is_root?` used by the navbar).
+- **lib/**: `datatables_decorators.rb` plus Haml scaffold templates.
+
+## Internationalization
+
+Full IT/EN duplication via the `(:locale)` URL scope. `config.i18n.default_locale = :it`.
+Locale files are split by concern: `config/locales/{layouts,models,views/*}/{en,it}.yml`
+plus Devise and simple_form dictionaries. `i18n-js` exposed translations to JavaScript.
+
+## Mail
+
+Devise mailers (password reset etc.) with views overridden under
+`app/views/devise/mailer/`. No custom mailers.
+
+## Testing & CI
+
+RSpec + Capybara under `spec/`; Travis CI ran migrations and the default rake task
+against PostgreSQL 9.4 on Ruby 2.2.1. Badges: Codacy, Code Climate, Travis.
+
+## Deployment
+
+Heroku: `Procfile` (`puma -t 5:5 -p $PORT`), `rails_12factor` for logging/static assets,
+`SECRET_KEY_BASE` from the environment in production. Database provisioning documented in
+the original README (PostgreSQL 9.4 with `trust` local auth — development convenience).
+
+## Third-party integrations
+
+- **Google Analytics** (`UA-80424858-1`) inline snippet in the layout.
+- **Google Maps JavaScript API + Places** for the honeymoon "suggest a stop" search box.
+- **Spotify** embedded playlist iframe + public playlist link.
+- **PayPal** donate button (disabled before the wedding due to fees; replaced by a bank
+  transfer IBAN displayed on the page).
+- **Google Fonts** (Roboto, Raleway, Montserrat, Cardo, Sanchez) loaded over `http://`.

--- a/docs/architecture/original-page-structure.md
+++ b/docs/architecture/original-page-structure.md
@@ -1,0 +1,107 @@
+# Original Page Structure & Frontend (2016)
+
+The site's look and feel comes from **"Vitality"**, a commercial Bootstrap 3 one-page
+theme (Start Bootstrap), used in its **vintage** style variant (`body.vintage`) with the
+**yellow** color scheme (`css/vitality-yellow.css`). All theme assets are vendored under
+`vendor/assets/` and served through the Rails asset pipeline.
+
+## Layout
+
+`app/views/layouts/application.html.haml`:
+
+- `lang="it"`, IE8/IE9 conditional classes, `viewport` meta
+- `_stylesheets` partial (theme + plugin CSS, Google Fonts over plain HTTP)
+- `body.vintage#page-top`
+- page yield → `static_pages/home`
+- `_footer` partial
+- `_javascripts` partial (jQuery + plugins + theme JS)
+- inline **Google Analytics** snippet (`UA-80424858-1`)
+- per-page `:page_title`, `:page_stylesheet`, `:page_javascript` content blocks
+
+## Home page composition
+
+`static_pages/home.html.haml` renders, in order:
+
+| # | Partial | Section id / element | Content |
+|---|---------|----------------------|---------|
+| 1 | `layouts/_navigation` | `nav.navbar-inverse.navbar-fixed-top` | Logo (`img/fashion/logo.png`); links vary by auth state: signed-in users on the root page get anchors (About, Locations, Partecipa, FAQ, Musica, Luna di Miele, Regalo) + language switch; anonymous users get Login/Register anchors |
+| 2 | `_header` | `header` | Full-screen hero, background `img/castle.jpg`, "Mauro e Beatrice — Con grande gioia annunciano il loro matrimonio", "Scopri" button, scroll-down arrow |
+| 3 | `_about` | `#about` | "Il nostro matrimonio — Sabato 1 Ottobre 2016", two icon cards linking to RSVP (`fa-edit`) and gift (`fa-gift`) sections |
+| 4 | `_locations` | `#locations.pricing` | Background `img/chiesa.jpg`; two cards: Cerimonia (Basilica di Sant'Alessandro in Colonna, Bergamo, 16.00) and Ricevimento (Tenuta Serradesca, Scanzorosciate, 18.30), each with a "Mappa" modal button |
+| 5 | `_participations` | `#participations.bg-gray` | RSVP. Final state: read-only list of confirmed guests rendered with jsrender from `/guests` JSON; the original code-validation + add-guest forms are commented out (deadline passed) |
+| 6 | `_quote` | `aside.cta-quote` | Schopenhauer quote over `img/proposta.jpg` |
+| 7 | `_faq` | `#faq.bg-gray` | Four icon cards: Parcheggio, Passaggi in Auto, Alloggio, Cibo |
+| 8 | `_messages` | `#message.bg-gray` | "Contattaci": couple's phone numbers + message/phone form POSTing JSON to `/messages` |
+| 9 | inline | `aside.cta-quote` | Image break, `img/shuttle.jpg` |
+| 10 | `_playlist` | `#playlist.bg-gray` | Spotify playlist embed (380×380 iframe) + "Apri la Playlist" button |
+| 11 | inline | `aside.cta-quote` | Image break, `img/menu.jpg` |
+| 12 | `_honey_moon` | `#trip.bg-gray.testimonials` | "Viaggio di Nozze": honeymoon description + Google Maps search box where guests dropped markers (saved to `places` via JSON) |
+| 13 | `_gift` | `#gift.bg-gray` | "Lista nozze": bank transfer details (recipient, IBAN, BIC), 11% progress bar, three columns describing what gifts fund (Festa e Cerimonia / Viaggio di Nozze / Quotidianità); PayPal button disabled |
+| 14 | `_map_modals` | `#churchMap`, `#restaurantMap`, `#searchMapModal` | Bootstrap modals: church/restaurant Google Maps embeds and the "why do you suggest this place" form |
+
+Footer (`layouts/_footer`): black background, three columns — countdown to
+`2016/10/01 16:00` (jquery.countdown), "Bergamo, Italy", mailto link — plus Spotify and
+GitHub icons and "© 2016 Mauro e Beatrice".
+
+Shared partials `shared/_login`, `shared/_register`, etc. render the Devise screens with
+the same theme for anonymous visitors.
+
+## Stylesheets (load order)
+
+1. `css/bootstrap/bootstrap.css` (Bootstrap 3.3.5, vendored as SCSS)
+2. `font-awesome/css/font-awesome.css` (vendored, with `fonts/`)
+3. Google Fonts: Roboto, Raleway (default), Montserrat, Cardo (modern), Sanchez, Cardo
+   (vintage) — all over `http://`
+4. Plugin CSS: owl-carousel (3 files), magnific-popup, background, animate.css
+5. Theme: `css/vitality-yellow.css` (other colour variants vendored but commented out)
+6. `application.css` (small app overrides, ~80 lines)
+7. Inline page CSS: maps search-box styles, embed-container styles in the modals partial
+
+## JavaScript (load order)
+
+1. Conditional IE<9: respond.js + html5shiv from MaxCDN
+2. `js/plugins/retina/retina.js`
+3. Core: `js/jquery.js` (1.11.0), `js/jquery.countdown.js`, `js/jsrender.js`,
+   `js/bootstrap/bootstrap.js` (3.3.5)
+4. Plugins: jquery.easing, classie, cbpAnimatedHeader, owl.carousel, magnific-popup,
+   background (core/transition/background), jquery.mixitup, wow.js, contact_me.js,
+   jqBootstrapValidation
+5. Theme: `js/vitality.js` (smooth scroll, navbar collapse, wow init, popups)
+6. Hashing: `js/plugins/jshash/{sha512,md5}.js` (used to "encrypt" the RSVP code
+   client-side — see security assessment)
+7. `application.js`: helpers (`capitalize`, `supplant`, `encrypt` = SHA-512 of lowercased
+   input) + footer countdown to the wedding date
+8. `i18n.js` (i18n-js translations)
+9. Per-page inline scripts rendered from ERB partials:
+   `static_pages/javascripts/_guests.js.erb` (RSVP JSON calls + jsrender rendering),
+   `_messages.js.erb` (contact form POST), `_maps_search_box.js.erb` (Google Maps Places
+   search, marker drop, suggestion modal POST to `/places`)
+10. DataTables (`js/jquery.dataTables.min.js`, `js/dataTables.bootstrap.min.js`) on the
+    `guests`/`messages`/`places` index pages
+
+## Images actually referenced by the home page
+
+From `vendor/assets/img/` (served under the `img/` logical path):
+
+- `img/castle.jpg` — hero header background
+- `img/chiesa.jpg` — locations section background
+- `img/proposta.jpg`, `img/shuttle.jpg`, `img/menu.jpg` — quote/image breaks
+- `img/fashion/logo.png` (+ `logo@2x.png` via retina.js) — navbar brand
+
+The rest of `vendor/assets/img/` (fashion gallery, people, portfolio, valdemossa,
+garden, terrace, stockholm…) ships with the theme demo or earlier drafts and is unused
+on the final page. `app/assets/images/stockholm.jpg` is likewise unused.
+
+## Theme directory map
+
+```
+vendor/assets/
+├── img/
+│   ├── img/                  # theme + wedding images (castle, chiesa, proposta, …)
+│   │   └── fashion/          # logo, profile, gallery (mostly unused on final page)
+│   └── plugins/datatables/   # sort icons
+├── javascripts/js/           # jquery, bootstrap, plugins/, vitality.js, datatables
+└── stylesheets/
+    ├── css/                  # bootstrap/, plugins/, vitality-*.css (10 colour variants)
+    └── font-awesome/         # css + fonts
+```

--- a/docs/superpowers/specs/2026-06-11-anniversary-static-site-design.md
+++ b/docs/superpowers/specs/2026-06-11-anniversary-static-site-design.md
@@ -1,0 +1,105 @@
+# 10th Wedding Anniversary Static Site — Design
+
+Date: 2026-06-11
+Status: approved (autonomous execution per owner's goal)
+
+## Background
+
+`wedwip` is the wedding website of Mauro & Beatrice (married 2016-10-01), built in 2016 as a
+Ruby on Rails 4.2 application and untouched for ~10 years. The stack is end-of-life
+(Ruby 2.2.1, Rails 4.2.6, jQuery 1.11, Bootstrap 3) and GitHub reports hundreds of
+Dependabot security alerts. The original dynamic features (Devise authentication, RSVP,
+guest messages, honeymoon place suggestions) are long past their purpose: the wedding
+happened, the RSVP deadline expired in 2016.
+
+## Goal
+
+For the 10th wedding anniversary (2026-10-01):
+
+1. Document the original architecture and project structure under `docs/`.
+2. Evaluate the security posture and document remediation.
+3. Replace the dynamic Rails app with a **secure static website**:
+   - a new anniversary landing page, and
+   - a faithful **static reproduction of the original 2016 site** (same layout, theme,
+     images, copy) reachable from the landing page.
+4. No authentication, no database, no server-side code.
+5. Assets are built/bundled from a TypeScript project.
+6. Deliver the work as a series of small atomic commits grouped into stacked PRs.
+
+## Non-goals
+
+- Reviving any dynamic feature (RSVP, login, message form submission, map suggestions).
+- Pixel-perfect rendering across legacy browsers (IE8/IE9 shims dropped).
+- Migrating git history or rewriting it to purge old secrets (documented instead).
+
+## Approaches considered
+
+1. **Vite + TypeScript multi-page site, original theme assets served verbatim for the
+   archive page (chosen).** The new landing page is a modern, minimal, bundled page. The
+   archive page is plain static HTML using the original Vitality theme CSS/JS/images copied
+   as-is — maximal fidelity with minimal risk, since a static page with no user input and no
+   secrets neutralizes the old jQuery/Bootstrap CVE exposure.
+2. Rewrite the archive page with modern CSS imitating the old look. Safer dependencies but
+   poor fidelity and much more work; rejected.
+3. Single hand-written HTML files with no build step. Simple, but the goal explicitly asks
+   for a TypeScript build, and a bundler gives minification, hashing and a dev server;
+   rejected.
+
+## Architecture
+
+```
+/                      ← legacy Rails app (removed in final PR)
+docs/                  ← architecture + security documentation
+site/                  ← new TypeScript static site (Vite)
+  index.html           ← 10th anniversary landing page (bundled TS/CSS)
+  src/                 ← TypeScript + CSS for the landing page
+  archive/index.html   ← static reproduction of the 2016 site (Italian)
+  archive/en/index.html← English version
+  public/archive/      ← original theme assets served verbatim (css/, js/, img/, fonts)
+```
+
+- **Build**: Vite multi-page (`index.html`, `archive/index.html`, `archive/en/index.html`
+  as rollup inputs). `npm run build` emits a fully static `dist/`.
+- **Landing page**: small TypeScript module (e.g. years/days-since counter), modern CSS,
+  links to `/archive/` and `/archive/en/`.
+- **Archive page**: HTML translated 1:1 from the original HAML partials (navigation,
+  header, about, locations, participations, quote, faq, contact, playlist quotes,
+  honeymoon, gift, map modals, footer), rendered as the "signed-in" root view since
+  authentication is retired. Original Vitality CSS/JS and images load from
+  `/archive/{css,js,img}/` unchanged.
+
+### Security-driven changes in the reproduction
+
+- **Redact personal/financial data**: real IBAN and BIC replaced with placeholders;
+  personal phone numbers removed; contact email kept (already public on the repo).
+- **No third-party trackers/APIs**: Google Analytics snippet removed; Google Maps
+  Places API (required a key) replaced with static map links/images; Spotify embed kept as
+  a passive iframe or reduced to a plain link.
+- **No form submissions**: RSVP/contact/suggestion forms rendered visually but inert
+  (disabled, with an "archived" note) — there is no backend.
+- **Legacy JS scope**: old jQuery/Bootstrap JS only on `/archive/*` pages, which contain
+  no user input handling and no sensitive data.
+- **Hardening**: `dependabot.yml` for npm, CI build+lint on PRs, CSP meta tag on new
+  pages, SECURITY.md, README rewrite.
+
+## PR series (stacked, each off the previous)
+
+| # | Branch | Content |
+|---|--------|---------|
+| 1 | `docs/original-architecture` | This spec + original architecture & page-structure docs |
+| 2 | `docs/security-posture` | Security assessment + remediation plan |
+| 3 | `feat/static-site-scaffold` | Vite+TS scaffold, lint, CI, dependabot config |
+| 4 | `feat/archive-theme-assets` | Original theme css/js/img copied into `site/public/archive/` |
+| 5 | `feat/archive-static-pages` | Static reproduction (IT + EN) of the 2016 home page |
+| 6 | `feat/anniversary-landing` | 10th anniversary landing page + navigation |
+| 7 | `chore/retire-rails-app` | Remove legacy Rails app, README, SECURITY.md, Pages deploy |
+
+PR 7 is the step that actually clears the Dependabot alerts (the vulnerable `Gemfile.lock`
+leaves the default branch). The Rails app remains available in git history and is fully
+described in `docs/`.
+
+## Testing / verification
+
+- `npm run build` and `npm run lint` green in CI on every PR.
+- Visual check of `dist/` pages via `vite preview` (landing + both archive locales).
+- Grep gate in review: no IBAN/BIC/phone numbers in any built output.


### PR DESCRIPTION
## 💍 10 years later — PR 1 of 7

First PR of the 10th-wedding-anniversary series: before touching anything, capture how the 2016 site was built.

### What's inside
- `docs/architecture/original-application.md` — the Rails 4.2 application: stack (Ruby 2.2.1, PostgreSQL 9.4, Devise, Haml, Heroku), routing, data model, controllers/decorators, i18n, CI and third-party integrations.
- `docs/architecture/original-page-structure.md` — the Vitality Bootstrap theme frontend: layout, the 14 home-page sections in render order, stylesheet/script load order, and which vendored images the final page actually used.
- `docs/superpowers/specs/2026-06-11-anniversary-static-site-design.md` — the design spec for the whole series: goals, chosen approach (Vite + TypeScript static site with a faithful static reproduction of the 2016 page) and the stacked PR plan.
- `docs/README.md` — docs index.

### PR series
1. **→ this PR** — original architecture docs
2. Security posture assessment
3. TypeScript static site scaffold (Vite)
4. Original theme assets ported for the archive page
5. Static reproduction of the 2016 site (IT + EN)
6. 10th anniversary landing page
7. Retire the legacy Rails app (clears the Dependabot alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)