### PR TITLE
feat: 10th anniversary landing page with navigation to the 2016 archive

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,16 +5,64 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Mauro e Beatrice — 10 anni di matrimonio"
+      content="Mauro e Beatrice — dieci anni di matrimonio, 1 ottobre 2016 – 1 ottobre 2026"
+    />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; script-src 'self'"
     />
     <title>Mauro e Beatrice | 10 anni</title>
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
-    <main id="app">
-      <h1>Mauro e Beatrice</h1>
-      <p>1 ottobre 2016 — 1 ottobre 2026</p>
-      <p><em>Il sito per il decimo anniversario è in costruzione.</em></p>
+    <main class="hero">
+      <p class="eyebrow">1 ottobre 2016 — 1 ottobre 2026</p>
+      <h1>Mauro <span class="amp">&amp;</span> Beatrice</h1>
+      <p class="tagline">Dieci anni dopo quel "sì" a Bergamo.</p>
+
+      <section class="counter" aria-label="Tempo insieme">
+        <div class="counter-item">
+          <span data-counter="years">–</span><small>anni</small>
+        </div>
+        <div class="counter-item">
+          <span data-counter="days">–</span><small>giorni</small>
+        </div>
+        <div class="counter-item">
+          <span data-counter="hours">–</span><small>ore</small>
+        </div>
+        <div class="counter-item">
+          <span data-counter="minutes">–</span><small>minuti</small>
+        </div>
+      </section>
+      <p class="anniversary-note" data-anniversary hidden></p>
     </main>
+
+    <section class="archive-nav">
+      <h2>Il sito originale del 2016</h2>
+      <p>
+        Il sito con cui annunciammo il matrimonio è stato conservato così
+        com'era: stesso tema, stesse immagini, stessi testi (con i dati
+        personali rimossi).
+      </p>
+      <nav class="archive-links">
+        <a class="card" href="archive/">
+          <strong>Visita l'archivio</strong>
+          <span>Versione italiana</span>
+        </a>
+        <a class="card" href="archive/en/">
+          <strong>Visit the archive</strong>
+          <span>English version</span>
+        </a>
+      </nav>
+    </section>
+
+    <footer>
+      <p>
+        © 2016–2026 Mauro e Beatrice ·
+        <a href="https://github.com/mberlanda/wedwip"
+          >github.com/mberlanda/wedwip</a
+        >
+      </p>
+    </footer>
   </body>
 </html>

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -1,3 +1,49 @@
 import './style.css';
 
 export const WEDDING_DATE = new Date('2016-10-01T16:00:00+02:00');
+
+export interface Elapsed {
+  years: number;
+  days: number;
+  hours: number;
+  minutes: number;
+}
+
+/** Whole years since the wedding, plus the remainder split into days/hours/minutes. */
+export function elapsedSince(from: Date, now: Date): Elapsed {
+  let years = now.getFullYear() - from.getFullYear();
+  const lastAnniversary = anniversaryOf(from, from.getFullYear() + years);
+  if (now < lastAnniversary) years -= 1;
+
+  const since = anniversaryOf(from, from.getFullYear() + years).getTime();
+  const rest = Math.max(0, now.getTime() - since);
+  return {
+    years,
+    days: Math.floor(rest / 86_400_000),
+    hours: Math.floor((rest % 86_400_000) / 3_600_000),
+    minutes: Math.floor((rest % 3_600_000) / 60_000),
+  };
+}
+
+function anniversaryOf(from: Date, year: number): Date {
+  const d = new Date(from.getTime());
+  d.setFullYear(year);
+  return d;
+}
+
+function render(now: Date): void {
+  const elapsed = elapsedSince(WEDDING_DATE, now);
+  for (const [key, value] of Object.entries(elapsed)) {
+    const el = document.querySelector(`[data-counter="${key}"]`);
+    if (el) el.textContent = String(value);
+  }
+
+  const note = document.querySelector<HTMLElement>('[data-anniversary]');
+  if (note && elapsed.years >= 10) {
+    note.hidden = false;
+    note.textContent = 'Buon decimo anniversario! 🥂';
+  }
+}
+
+render(new Date());
+setInterval(() => render(new Date()), 30_000);

--- a/site/src/style.css
+++ b/site/src/style.css
@@ -1,10 +1,146 @@
 :root {
-  font-family: system-ui, sans-serif;
+  --ink: #2b2622;
+  --paper: #faf6f0;
+  --accent: #b8860b;
+  --muted: #7a7068;
+  font-family: Georgia, 'Times New Roman', serif;
+  color: var(--ink);
+  background: var(--paper);
 }
 
-#app {
-  max-width: 40rem;
-  margin: 4rem auto;
-  padding: 0 1rem;
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-align: center;
+  padding: 0 1.25rem;
+}
+
+.hero {
+  padding: 14vh 0 6vh;
+  max-width: 42rem;
+}
+
+.eyebrow {
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0 0 1rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 7vw, 4.2rem);
+  font-weight: 400;
+  margin: 0;
+  line-height: 1.1;
+}
+
+.amp {
+  color: var(--accent);
+  font-style: italic;
+}
+
+.tagline {
+  font-style: italic;
+  color: var(--muted);
+  margin: 1rem 0 0;
+}
+
+.counter {
+  display: flex;
+  justify-content: center;
+  gap: clamp(1rem, 5vw, 2.5rem);
+  margin-top: 3rem;
+}
+
+.counter-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.counter-item span {
+  font-size: clamp(1.6rem, 4.5vw, 2.6rem);
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+}
+
+.counter-item small {
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.anniversary-note {
+  margin-top: 2rem;
+  font-style: italic;
+  color: var(--accent);
+}
+
+.archive-nav {
+  max-width: 42rem;
+  padding: 3rem 0;
+  border-top: 1px solid rgba(43, 38, 34, 0.15);
+}
+
+.archive-nav h2 {
+  font-weight: 400;
+  margin: 0 0 0.75rem;
+}
+
+.archive-nav > p {
+  color: var(--muted);
+  margin: 0 0 2rem;
+}
+
+.archive-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.25rem 2rem;
+  min-width: 14rem;
+  border: 1px solid rgba(43, 38, 34, 0.25);
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--ink);
+  background: #fff;
+  transition:
+    border-color 0.2s,
+    transform 0.2s;
+}
+
+.card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+}
+
+.card span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+footer {
+  margin-top: auto;
+  padding: 2.5rem 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+footer a {
+  color: inherit;
 }


### PR DESCRIPTION
## 🥂 10 years later — PR 6 of 7 (stacked on #6)

The new front door: a minimal, dependency-free landing page for the 10th anniversary (1 October 2026), replacing the scaffold placeholder.

### What's inside
- **Landing page** (`site/index.html` + `src/style.css`): system serif stack — no external fonts, no trackers, nothing third-party — with a **CSP meta tag** (`default-src 'self'`) and navigation cards to the archived 2016 site in both languages (`/archive/`, `/archive/en/`).
- **TypeScript counter** (`src/main.ts`): `elapsedSince()` splits time since the wedding into whole years + days/hours/minutes (anniversary-aware), and reveals a greeting once the 10th anniversary arrives. Bundled by Vite; the whole page weighs ~2.4 kB gzipped.

### Verification
`npm run lint` + `npm run build` green; built page totals: 0.92 + 0.75 + 0.72 kB gzipped.

### PR series
1. #2 docs · 2. #3 security · 3. #4 scaffold · 4. #5 assets · 5. #6 archive pages · **6. → this PR** · 7. retire Rails

🤖 Generated with [Claude Code](https://claude.com/claude-code)